### PR TITLE
Fix production GraphQL endpoint

### DIFF
--- a/Shared/Livia/Client.swift
+++ b/Shared/Livia/Client.swift
@@ -14,7 +14,7 @@ import Foundation
 class GraphQLClient {
     static let shared = GraphQLClient()
 
-    private let endpoint = URL(string: "https://prod3.livia.arryan.xyz/graphql")!
+    private let endpoint = URL(string: "https://livia.arryan.xyz/graphql")!
     private let session = URLSession.shared
 
     private init() {}


### PR DESCRIPTION
## What changed

Point the shared GraphQL client at the healthy global production endpoint instead of the retired `prod3` hostname.

## Why

`prod3.livia.arryan.xyz` no longer resolves, causing all modern shared GraphQL requests to fail before reaching Livia.

## Impact

Cosmofy uses the working global production endpoint, currently backed by the Oracle deployment.

## Validation

- Confirmed `https://livia.arryan.xyz/graphql` returns HTTP 200 and identifies the server as `oracle`.
- Confirmed the old `prod3` hostname does not resolve.
- Diff and whitespace checks passed.
- Full Xcode compilation is unavailable because this Mac is configured with Command Line Tools rather than Xcode.
